### PR TITLE
バックエンドを実装

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,6 +3,8 @@ module backend
 go 1.21
 
 require (
+	github.com/go-chi/chi/v5 v5.0.12
+	github.com/go-chi/cors v1.2.1
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/google/uuid v1.6.0
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,2 +1,8 @@
+github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
+github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
+github.com/go-chi/cors v1.2.1/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
 github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/backend/internal/domain/domain.go
+++ b/backend/internal/domain/domain.go
@@ -1,0 +1,24 @@
+package domain
+
+import (
+	"context"
+	"time"
+)
+
+// Todo represents a todo item entity
+type Todo struct {
+	ID          string    `json:"id"`
+	Title       string    `json:"title"`
+	IsCompleted bool      `json:"is_completed"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// TodoRepository defines the interface for todo data access
+type TodoRepository interface {
+	List(ctx context.Context) ([]Todo, error)
+	GetByID(ctx context.Context, id string) (*Todo, error)
+	Create(ctx context.Context, title string) (*Todo, error)
+	Update(ctx context.Context, id string, title string, isCompleted bool) (*Todo, error)
+	Delete(ctx context.Context, id string) error
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/cors"
+)
+
+// NewRouter creates a new chi router with CORS middleware
+func NewRouter(todoHandler *TodoHandler) http.Handler {
+	r := chi.NewRouter()
+
+	// Middleware
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+	r.Use(middleware.RequestID)
+
+	// CORS configuration for localhost:3000 (Nuxt frontend)
+	r.Use(cors.Handler(cors.Options{
+		AllowedOrigins:   []string{"http://localhost:3000"},
+		AllowedMethods:   []string{"GET", "POST", "PATCH", "DELETE", "OPTIONS"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
+		ExposedHeaders:   []string{"Link"},
+		AllowCredentials: true,
+		MaxAge:           300,
+	}))
+
+	// Health check endpoint
+	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+
+	// Root endpoint
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Hello World from Go Backend!"))
+	})
+
+	// API routes
+	r.Route("/api", func(r chi.Router) {
+		r.Route("/todos", func(r chi.Router) {
+			r.Get("/", todoHandler.ListTodos)
+			r.Post("/", todoHandler.CreateTodo)
+			r.Patch("/{id}", todoHandler.UpdateTodoCompleted)
+			r.Delete("/{id}", todoHandler.DeleteTodo)
+		})
+	})
+
+	return r
+}

--- a/backend/internal/handler/todo_handler.go
+++ b/backend/internal/handler/todo_handler.go
@@ -1,0 +1,129 @@
+package handler
+
+import (
+	"backend/internal/domain"
+	"backend/internal/usecase"
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// TodoHandler handles HTTP requests for todos
+type TodoHandler struct {
+	usecase *usecase.TodoUsecase
+}
+
+// NewTodoHandler creates a new TodoHandler
+func NewTodoHandler(usecase *usecase.TodoUsecase) *TodoHandler {
+	return &TodoHandler{usecase: usecase}
+}
+
+// CreateTodoRequest represents the request body for creating a todo
+type CreateTodoRequest struct {
+	Title string `json:"title"`
+}
+
+// UpdateTodoRequest represents the request body for updating a todo's completion status
+type UpdateTodoRequest struct {
+	IsCompleted bool `json:"is_completed"`
+}
+
+// ErrorResponse represents an error response
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// ListTodos handles GET /api/todos
+func (h *TodoHandler) ListTodos(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	todos, err := h.usecase.List(ctx)
+	if err != nil {
+		h.respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Return empty array instead of null when no todos
+	if todos == nil {
+		todos = []domain.Todo{}
+	}
+
+	h.respondJSON(w, http.StatusOK, todos)
+}
+
+// CreateTodo handles POST /api/todos
+func (h *TodoHandler) CreateTodo(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req CreateTodoRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.respondError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	if req.Title == "" {
+		h.respondError(w, http.StatusBadRequest, "Title is required")
+		return
+	}
+
+	todo, err := h.usecase.Create(ctx, req.Title)
+	if err != nil {
+		h.respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	h.respondJSON(w, http.StatusCreated, todo)
+}
+
+// UpdateTodoCompleted handles PATCH /api/todos/{id}
+func (h *TodoHandler) UpdateTodoCompleted(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	id := chi.URLParam(r, "id")
+
+	var req UpdateTodoRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.respondError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	todo, err := h.usecase.UpdateCompleted(ctx, id, req.IsCompleted)
+	if err != nil {
+		h.respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	if todo == nil {
+		h.respondError(w, http.StatusNotFound, "Todo not found")
+		return
+	}
+
+	h.respondJSON(w, http.StatusOK, todo)
+}
+
+// DeleteTodo handles DELETE /api/todos/{id}
+func (h *TodoHandler) DeleteTodo(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	id := chi.URLParam(r, "id")
+
+	if err := h.usecase.Delete(ctx, id); err != nil {
+		h.respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// respondJSON sends a JSON response
+func (h *TodoHandler) respondJSON(w http.ResponseWriter, status int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// respondError sends an error response
+func (h *TodoHandler) respondError(w http.ResponseWriter, status int, message string) {
+	h.respondJSON(w, status, ErrorResponse{Error: message})
+}

--- a/backend/internal/infrastructure/db/repository_adapter.go
+++ b/backend/internal/infrastructure/db/repository_adapter.go
@@ -1,0 +1,89 @@
+package db
+
+import (
+	"backend/internal/domain"
+	"context"
+)
+
+// TodoRepositoryAdapter adapts the sqlc-based TodoRepository to the domain.TodoRepository interface
+type TodoRepositoryAdapter struct {
+	repo *TodoRepository
+}
+
+// NewTodoRepositoryAdapter creates a new adapter
+func NewTodoRepositoryAdapter(repo *TodoRepository) *TodoRepositoryAdapter {
+	return &TodoRepositoryAdapter{repo: repo}
+}
+
+// List returns all todos
+func (a *TodoRepositoryAdapter) List(ctx context.Context) ([]domain.Todo, error) {
+	todos, err := a.repo.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return toDomainTodos(todos), nil
+}
+
+// GetByID returns a todo by ID
+func (a *TodoRepositoryAdapter) GetByID(ctx context.Context, id string) (*domain.Todo, error) {
+	todo, err := a.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if todo == nil {
+		return nil, nil
+	}
+	return toDomainTodo(todo), nil
+}
+
+// Create creates a new todo
+func (a *TodoRepositoryAdapter) Create(ctx context.Context, title string) (*domain.Todo, error) {
+	todo, err := a.repo.Create(ctx, title)
+	if err != nil {
+		return nil, err
+	}
+	return toDomainTodo(todo), nil
+}
+
+// Update updates a todo
+func (a *TodoRepositoryAdapter) Update(ctx context.Context, id string, title string, isCompleted bool) (*domain.Todo, error) {
+	todo, err := a.repo.Update(ctx, id, title, isCompleted)
+	if err != nil {
+		return nil, err
+	}
+	if todo == nil {
+		return nil, nil
+	}
+	return toDomainTodo(todo), nil
+}
+
+// Delete deletes a todo
+func (a *TodoRepositoryAdapter) Delete(ctx context.Context, id string) error {
+	return a.repo.Delete(ctx, id)
+}
+
+// toDomainTodo converts a db.Todo to domain.Todo
+func toDomainTodo(t *Todo) *domain.Todo {
+	return &domain.Todo{
+		ID:          t.ID,
+		Title:       t.Title,
+		IsCompleted: t.IsCompleted,
+		CreatedAt:   t.CreatedAt,
+		UpdatedAt:   t.UpdatedAt,
+	}
+}
+
+// toDomainTodos converts a slice of db.Todo to domain.Todo
+func toDomainTodos(todos []Todo) []domain.Todo {
+	result := make([]domain.Todo, len(todos))
+	for i, t := range todos {
+		result[i] = domain.Todo{
+			ID:          t.ID,
+			Title:       t.Title,
+			IsCompleted: t.IsCompleted,
+			CreatedAt:   t.CreatedAt,
+			UpdatedAt:   t.UpdatedAt,
+		}
+	}
+	return result
+}

--- a/backend/internal/usecase/todo_usecase.go
+++ b/backend/internal/usecase/todo_usecase.go
@@ -1,0 +1,45 @@
+package usecase
+
+import (
+	"backend/internal/domain"
+	"context"
+)
+
+// TodoUsecase handles business logic for todos
+type TodoUsecase struct {
+	repo domain.TodoRepository
+}
+
+// NewTodoUsecase creates a new TodoUsecase
+func NewTodoUsecase(repo domain.TodoRepository) *TodoUsecase {
+	return &TodoUsecase{repo: repo}
+}
+
+// List returns all todos
+func (u *TodoUsecase) List(ctx context.Context) ([]domain.Todo, error) {
+	return u.repo.List(ctx)
+}
+
+// Create creates a new todo with the given title
+func (u *TodoUsecase) Create(ctx context.Context, title string) (*domain.Todo, error) {
+	return u.repo.Create(ctx, title)
+}
+
+// UpdateCompleted updates the completion status of a todo
+func (u *TodoUsecase) UpdateCompleted(ctx context.Context, id string, isCompleted bool) (*domain.Todo, error) {
+	// First get the existing todo to preserve the title
+	existing, err := u.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if existing == nil {
+		return nil, nil // Not found
+	}
+
+	return u.repo.Update(ctx, id, existing.Title, isCompleted)
+}
+
+// Delete deletes a todo by ID
+func (u *TodoUsecase) Delete(ctx context.Context, id string) error {
+	return u.repo.Delete(ctx, id)
+}


### PR DESCRIPTION
## Summary

chi routerを使用して、3層アーキテクチャ（Handler → Usecase → Repository）に従ったTodo CRUD APIを実装しました。

## Changes

### New Dependencies
- `github.com/go-chi/chi/v5` - HTTP router
- `github.com/go-chi/cors` - CORS middleware

### New Files
| File | Description |
|------|-------------|
| [internal/domain/domain.go](cci:7://file:///home/tomoya-nakabayashi/devin/devin_todo_list/backend/internal/domain/domain.go:0:0-0:0) | Todo entity と TodoRepository interface |
| [internal/usecase/todo_usecase.go](cci:7://file:///home/tomoya-nakabayashi/devin/devin_todo_list/backend/internal/usecase/todo_usecase.go:0:0-0:0) | ビジネスロジック層 |
| [internal/handler/todo_handler.go](cci:7://file:///home/tomoya-nakabayashi/devin/devin_todo_list/backend/internal/handler/todo_handler.go:0:0-0:0) | HTTPハンドラー |
| [internal/handler/router.go](cci:7://file:///home/tomoya-nakabayashi/devin/devin_todo_list/backend/internal/handler/router.go:0:0-0:0) | Chi router + CORS設定 |
| [internal/infrastructure/db/repository_adapter.go](cci:7://file:///home/tomoya-nakabayashi/devin/devin_todo_list/backend/internal/infrastructure/db/repository_adapter.go:0:0-0:0) | DB層をdomain interfaceに適合させるアダプター |

### Modified Files
- [go.mod](cci:7://file:///home/tomoya-nakabayashi/devin/devin_todo_list/backend/go.mod:0:0-0:0) - chi/cors依存関係を追加
- [main.go](cci:7://file:///home/tomoya-nakabayashi/devin/devin_todo_list/backend/main.go:0:0-0:0) - chi routerと依存性注入を導入

## API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/api/todos` | 一覧取得 |
| `POST` | `/api/todos` | 新規作成 |
| `PATCH` | `/api/todos/{id}` | 完了フラグ更新 |
| `DELETE` | `/api/todos/{id}` | 削除 |

## CORS Configuration

`http://localhost:3000` (Nuxt frontend) からのアクセスを許可。

## Testing

```bash
# List todos
curl http://localhost:8080/api/todos

# Create todo
curl -X POST http://localhost:8080/api/todos \
  -H "Content-Type: application/json" \
  -d '{"title": "Test Todo"}'

# Update todo
curl -X PATCH http://localhost:8080/api/todos/{id} \
  -H "Content-Type: application/json" \
  -d '{"is_completed": true}'

# Delete todo
curl -X DELETE http://localhost:8080/api/todos/{id}