### PR TITLE
polishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,142 @@
-# devin_todo_list
+# Todo App
+
+Go + Nuxt.js で構築した Todo アプリケーションです。
+
+## 技術スタック
+
+| Layer | Technology |
+|-------|------------|
+| Frontend | Nuxt 3, Vue 3, Tailwind CSS |
+| Backend | Go 1.21, chi router |
+| Database | MySQL 8.0 |
+| Infrastructure | Docker Compose |
+
+## 起動方法
+
+### 1. 環境変数の設定
+
+```bash
+cp .env.example .env
+```
+
+### 2. Docker Compose で起動
+
+```bash
+# マイグレーションを含めて起動
+docker compose --profile tools up -d
+
+# 通常起動
+docker compose up -d
+```
+
+### 3. アクセス
+
+- **Frontend**: http://localhost:3000
+- **Backend API**: http://localhost:8080
+
+## API 仕様
+
+### Base URL
+```
+http://localhost:8080
+```
+
+### Endpoints
+
+#### Todo 一覧取得
+```
+GET /api/todos
+```
+
+**Response:**
+```json
+[
+  {
+    "id": "uuid",
+    "title": "Todo title",
+    "is_completed": false,
+    "created_at": "2024-01-01T00:00:00Z",
+    "updated_at": "2024-01-01T00:00:00Z"
+  }
+]
+```
+
+---
+
+#### Todo 新規作成
+```
+POST /api/todos
+```
+
+**Request Body:**
+```json
+{
+  "title": "New todo"
+}
+```
+
+**Response:** `201 Created`
+```json
+{
+  "id": "uuid",
+  "title": "New todo",
+  "is_completed": false,
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-01-01T00:00:00Z"
+}
+```
+
+---
+
+#### Todo 完了状態更新
+```
+PATCH /api/todos/{id}
+```
+
+**Request Body:**
+```json
+{
+  "is_completed": true
+}
+```
+
+**Response:** `200 OK`
+```json
+{
+  "id": "uuid",
+  "title": "Todo title",
+  "is_completed": true,
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-01-01T00:00:00Z"
+}
+```
+
+---
+
+#### Todo 削除
+```
+DELETE /api/todos/{id}
+```
+
+**Response:** `204 No Content`
+
+## 開発
+
+### テスト実行
+
+```bash
+cd backend
+go test ./...
+```
+
+### ビルド
+
+```bash
+# Backend
+cd backend
+go build ./...
+
+# Frontend
+cd frontend
+npm run build
+```

--- a/backend/internal/usecase/todo_usecase_test.go
+++ b/backend/internal/usecase/todo_usecase_test.go
@@ -1,0 +1,355 @@
+package usecase
+
+import (
+	"backend/internal/domain"
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// mockTodoRepository is a mock implementation of domain.TodoRepository
+type mockTodoRepository struct {
+	todos       map[string]*domain.Todo
+	listErr     error
+	getByIDErr  error
+	createErr   error
+	updateErr   error
+	deleteErr   error
+	createCount int
+}
+
+func newMockRepo() *mockTodoRepository {
+	return &mockTodoRepository{
+		todos: make(map[string]*domain.Todo),
+	}
+}
+
+func (m *mockTodoRepository) List(ctx context.Context) ([]domain.Todo, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	result := make([]domain.Todo, 0, len(m.todos))
+	for _, t := range m.todos {
+		result = append(result, *t)
+	}
+	return result, nil
+}
+
+func (m *mockTodoRepository) GetByID(ctx context.Context, id string) (*domain.Todo, error) {
+	if m.getByIDErr != nil {
+		return nil, m.getByIDErr
+	}
+	todo, ok := m.todos[id]
+	if !ok {
+		return nil, nil
+	}
+	return todo, nil
+}
+
+func (m *mockTodoRepository) Create(ctx context.Context, title string) (*domain.Todo, error) {
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+	m.createCount++
+	todo := &domain.Todo{
+		ID:          "test-id",
+		Title:       title,
+		IsCompleted: false,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+	m.todos[todo.ID] = todo
+	return todo, nil
+}
+
+func (m *mockTodoRepository) Update(ctx context.Context, id string, title string, isCompleted bool) (*domain.Todo, error) {
+	if m.updateErr != nil {
+		return nil, m.updateErr
+	}
+	todo, ok := m.todos[id]
+	if !ok {
+		return nil, nil
+	}
+	todo.Title = title
+	todo.IsCompleted = isCompleted
+	todo.UpdatedAt = time.Now()
+	return todo, nil
+}
+
+func (m *mockTodoRepository) Delete(ctx context.Context, id string) error {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	delete(m.todos, id)
+	return nil
+}
+
+func TestTodoUsecase_UpdateCompleted(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupRepo   func(*mockTodoRepository)
+		id          string
+		isCompleted bool
+		wantErr     bool
+		wantNil     bool
+		wantStatus  bool
+	}{
+		{
+			name: "successfully toggle to completed",
+			setupRepo: func(m *mockTodoRepository) {
+				m.todos["1"] = &domain.Todo{
+					ID:          "1",
+					Title:       "Test Todo",
+					IsCompleted: false,
+				}
+			},
+			id:          "1",
+			isCompleted: true,
+			wantErr:     false,
+			wantNil:     false,
+			wantStatus:  true,
+		},
+		{
+			name: "successfully toggle to incomplete",
+			setupRepo: func(m *mockTodoRepository) {
+				m.todos["1"] = &domain.Todo{
+					ID:          "1",
+					Title:       "Test Todo",
+					IsCompleted: true,
+				}
+			},
+			id:          "1",
+			isCompleted: false,
+			wantErr:     false,
+			wantNil:     false,
+			wantStatus:  false,
+		},
+		{
+			name:        "returns nil when todo not found",
+			setupRepo:   func(m *mockTodoRepository) {},
+			id:          "nonexistent",
+			isCompleted: true,
+			wantErr:     false,
+			wantNil:     true,
+		},
+		{
+			name: "returns error when GetByID fails",
+			setupRepo: func(m *mockTodoRepository) {
+				m.getByIDErr = errors.New("database error")
+			},
+			id:          "1",
+			isCompleted: true,
+			wantErr:     true,
+		},
+		{
+			name: "returns error when Update fails",
+			setupRepo: func(m *mockTodoRepository) {
+				m.todos["1"] = &domain.Todo{
+					ID:          "1",
+					Title:       "Test Todo",
+					IsCompleted: false,
+				}
+				m.updateErr = errors.New("update error")
+			},
+			id:          "1",
+			isCompleted: true,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newMockRepo()
+			tt.setupRepo(repo)
+			usecase := NewTodoUsecase(repo)
+
+			result, err := usecase.UpdateCompleted(context.Background(), tt.id, tt.isCompleted)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf("expected nil, got %+v", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Error("expected non-nil result, got nil")
+				return
+			}
+
+			if result.IsCompleted != tt.wantStatus {
+				t.Errorf("expected IsCompleted=%v, got %v", tt.wantStatus, result.IsCompleted)
+			}
+		})
+	}
+}
+
+func TestTodoUsecase_Create(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupRepo func(*mockTodoRepository)
+		title     string
+		wantErr   bool
+		wantTitle string
+	}{
+		{
+			name:      "successfully creates todo",
+			setupRepo: func(m *mockTodoRepository) {},
+			title:     "New Todo",
+			wantErr:   false,
+			wantTitle: "New Todo",
+		},
+		{
+			name: "returns error when Create fails",
+			setupRepo: func(m *mockTodoRepository) {
+				m.createErr = errors.New("create error")
+			},
+			title:   "New Todo",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newMockRepo()
+			tt.setupRepo(repo)
+			usecase := NewTodoUsecase(repo)
+
+			result, err := usecase.Create(context.Background(), tt.title)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if result.Title != tt.wantTitle {
+				t.Errorf("expected title=%q, got %q", tt.wantTitle, result.Title)
+			}
+		})
+	}
+}
+
+func TestTodoUsecase_List(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupRepo func(*mockTodoRepository)
+		wantErr   bool
+		wantCount int
+	}{
+		{
+			name:      "returns empty list",
+			setupRepo: func(m *mockTodoRepository) {},
+			wantErr:   false,
+			wantCount: 0,
+		},
+		{
+			name: "returns all todos",
+			setupRepo: func(m *mockTodoRepository) {
+				m.todos["1"] = &domain.Todo{ID: "1", Title: "Todo 1"}
+				m.todos["2"] = &domain.Todo{ID: "2", Title: "Todo 2"}
+			},
+			wantErr:   false,
+			wantCount: 2,
+		},
+		{
+			name: "returns error when List fails",
+			setupRepo: func(m *mockTodoRepository) {
+				m.listErr = errors.New("list error")
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newMockRepo()
+			tt.setupRepo(repo)
+			usecase := NewTodoUsecase(repo)
+
+			result, err := usecase.List(context.Background())
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if len(result) != tt.wantCount {
+				t.Errorf("expected %d todos, got %d", tt.wantCount, len(result))
+			}
+		})
+	}
+}
+
+func TestTodoUsecase_Delete(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupRepo func(*mockTodoRepository)
+		id        string
+		wantErr   bool
+	}{
+		{
+			name: "successfully deletes todo",
+			setupRepo: func(m *mockTodoRepository) {
+				m.todos["1"] = &domain.Todo{ID: "1", Title: "Todo 1"}
+			},
+			id:      "1",
+			wantErr: false,
+		},
+		{
+			name: "returns error when Delete fails",
+			setupRepo: func(m *mockTodoRepository) {
+				m.deleteErr = errors.New("delete error")
+			},
+			id:      "1",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newMockRepo()
+			tt.setupRepo(repo)
+			usecase := NewTodoUsecase(repo)
+
+			err := usecase.Delete(context.Background(), tt.id)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

テーブル駆動テストとREADMEドキュメントを追加し、最終調整を行いました。

## Changes

### New Files
| File | Description |
|------|-------------|
| [backend/internal/usecase/todo_usecase_test.go](cci:7://file:///home/tomoya-nakabayashi/devin/devin_todo_list/backend/internal/usecase/todo_usecase_test.go:0:0-0:0) | Usecaseのテーブル駆動テスト |

### Modified Files
| File | Description |
|------|-------------|
| [README.md](cci:7://file:///home/tomoya-nakabayashi/devin/devin_todo_list/README.md:0:0-0:0) | プロジェクト概要、起動方法、API仕様を追加 |

## Table-Driven Tests

[TodoUsecase](cci:2://file:///home/tomoya-nakabayashi/devin/devin_todo_list/backend/internal/usecase/todo_usecase.go:8:0-10:1)の全メソッドをカバー:

| Test | Cases |
|------|-------|
| [TestTodoUsecase_UpdateCompleted](cci:1://file:///home/tomoya-nakabayashi/devin/devin_todo_list/backend/internal/usecase/todo_usecase_test.go:87:0-197:1) | 5ケース（成功/not found/エラー） |
| [TestTodoUsecase_Create](cci:1://file:///home/tomoya-nakabayashi/devin/devin_todo_list/backend/internal/usecase/todo_usecase_test.go:199:0-249:1) | 2ケース（成功/エラー） |
| [TestTodoUsecase_List](cci:1://file:///home/tomoya-nakabayashi/devin/devin_todo_list/backend/internal/usecase/todo_usecase_test.go:251:0-307:1) | 3ケース（空/複数/エラー） |
| [TestTodoUsecase_Delete](cci:1://file:///home/tomoya-nakabayashi/devin/devin_todo_list/backend/internal/usecase/todo_usecase_test.go:309:0-354:1) | 2ケース（成功/エラー） |

**計12テストケース - 全パス** ✅

## README Contents

- 技術スタック
- Docker Composeでの起動方法
- API仕様（全4エンドポイント）
- 開発コマンド（テスト/ビルド）

## Docker Persistence

✅ `mysql_data`ボリュームでデータ永続化済み

## Test Results
